### PR TITLE
feat(prediction): add prediction response page and API integration

### DIFF
--- a/book_sync/app/templates/prediction-responce.html
+++ b/book_sync/app/templates/prediction-responce.html
@@ -1,0 +1,304 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block title %}Résultat de Prédiction - BookSync{% endblock %}
+
+{% block content %}
+<div class="px-4 sm:px-6 lg:px-8 py-8">
+    <!-- Titre principal -->
+    <div class="mb-8">
+        <div class="flex items-center space-x-3 mb-2">
+            <div class="p-2 bg-green-600 rounded-lg">
+                <svg class="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                </svg>
+            </div>
+            <h1 class="text-3xl font-bold text-gray-900 dark:text-white">Vos recommandations personnalisées</h1>
+        </div>
+        <p class="text-gray-600 dark:text-gray-400">
+            Basée sur vos préférences et votre collection, voici notre sélection de séries qui devraient vous plaire.
+        </p>
+    </div>
+
+    <!-- Résumé des critères utilisés -->
+    <div class="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-6 mb-8">
+        <h2 class="text-lg font-semibold text-blue-900 dark:text-blue-100 mb-3">Critères de prédiction</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 text-sm">
+            {% if user_data.age %}
+            <div class="flex items-center space-x-2">
+                <span class="font-medium text-blue-800 dark:text-blue-200">Âge:</span>
+                <span class="text-blue-700 dark:text-blue-300">{{ user_data.age }} ans</span>
+            </div>
+            {% endif %}
+            
+            {% if user_data.genre %}
+            <div class="flex items-center space-x-2">
+                <span class="font-medium text-blue-800 dark:text-blue-200">Genre:</span>
+                <span class="text-blue-700 dark:text-blue-300">{{ user_data.genre }}</span>
+            </div>
+            {% endif %}
+            
+            {% if user_data.mood %}
+            <div class="flex items-center space-x-2">
+                <span class="font-medium text-blue-800 dark:text-blue-200">Humeur:</span>
+                <span class="text-blue-700 dark:text-blue-300">{{ user_data.mood }}</span>
+            </div>
+            {% endif %}
+            
+            {% if user_data.prediction_type %}
+            <div class="flex items-center space-x-2">
+                <span class="font-medium text-blue-800 dark:text-blue-200">Type:</span>
+                <span class="text-blue-700 dark:text-blue-300">{{ user_data.prediction_type }}</span>
+            </div>
+            {% endif %}
+            
+            {% if user_data.genres %}
+            <div class="col-span-full">
+                <span class="font-medium text-blue-800 dark:text-blue-200">Genres préférés:</span>
+                <div class="flex flex-wrap gap-1 mt-1">
+                    {% for genre in user_data.genres %}
+                    <span class="bg-blue-100 dark:bg-blue-800 text-blue-800 dark:text-blue-200 text-xs px-2 py-1 rounded">{{ genre }}</span>
+                    {% endfor %}
+                </div>
+            </div>
+            {% endif %}
+            
+            {% if user_data.categories %}
+            <div class="col-span-full">
+                <span class="font-medium text-blue-800 dark:text-blue-200">Catégories préférées:</span>
+                <div class="flex flex-wrap gap-1 mt-1">
+                    {% for category in user_data.categories %}
+                    <span class="bg-blue-100 dark:bg-blue-800 text-blue-800 dark:text-blue-200 text-xs px-2 py-1 rounded">{{ category }}</span>
+                    {% endfor %}
+                </div>
+            </div>
+            {% endif %}
+            
+            {% if user_data.comment %}
+            <div class="col-span-full">
+                <span class="font-medium text-blue-800 dark:text-blue-200">Votre message:</span>
+                <div class="mt-2 p-3 bg-blue-100 dark:bg-blue-800/50 rounded-lg border-l-4 border-blue-500">
+                    <p class="text-blue-900 dark:text-blue-100 italic text-sm leading-relaxed">
+                        "{{ user_data.comment }}"
+                    </p>
+                </div>
+            </div>
+            {% endif %}
+        </div>
+    </div>
+
+    <!-- Message d'erreur API -->
+    {% if api_error %}
+    <div class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-700 rounded-lg p-6 mb-8">
+        <div class="flex items-center space-x-3">
+            <svg class="w-6 h-6 text-red-600 dark:text-red-400" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"/>
+            </svg>
+            <h3 class="text-lg font-medium text-red-800 dark:text-red-200">Erreur de prédiction</h3>
+        </div>
+        <p class="mt-2 text-red-700 dark:text-red-300">
+            {{ api_error }}
+        </p>
+        <div class="mt-4">
+            <a href="{% url 'prediction' %}" class="inline-flex items-center px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg transition">
+                <svg class="w-4 h-4 mr-2" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M15.41 16.09l-4.58-4.59 4.58-4.59L14 5.5l-6 6 6 6z"/>
+                </svg>
+                Réessayer la prédiction
+            </a>
+        </div>
+    </div>
+    {% endif %}
+
+    <!-- Message si aucune prédiction -->
+    {% if not predictions or predictions|length == 0 %}
+    <div class="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-700 rounded-lg p-6">
+        <div class="flex items-center space-x-3">
+            <svg class="w-6 h-6 text-yellow-600 dark:text-yellow-400" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"/>
+            </svg>
+            <h3 class="text-lg font-medium text-yellow-800 dark:text-yellow-200">Aucune prédiction disponible</h3>
+        </div>
+        <p class="mt-2 text-yellow-700 dark:text-yellow-300">
+            Nous n'avons pas pu générer de recommandations basées sur vos critères actuels. 
+            Essayez avec des préférences différentes ou enrichissez votre collection.
+        </p>
+        <div class="mt-4">
+            <a href="{% url 'prediction' %}" class="inline-flex items-center px-4 py-2 bg-yellow-600 hover:bg-yellow-700 text-white rounded-lg transition">
+                <svg class="w-4 h-4 mr-2" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M15.41 16.09l-4.58-4.59 4.58-4.59L14 5.5l-6 6 6 6z"/>
+                </svg>
+                Refaire une prédiction
+            </a>
+        </div>
+    </div>
+    {% else %}
+
+    <!-- Liste des prédictions -->
+    <div class="space-y-6">
+        <div class="flex items-center justify-between">
+            <h2 class="text-xl font-semibold text-gray-900 dark:text-white">
+                Nos recommandations ({{ predictions|length }} série{{ predictions|length|pluralize }})
+            </h2>
+            <div class="flex space-x-2">
+                <span class="text-sm text-gray-500 dark:text-gray-400">Score de correspondance</span>
+                <div class="flex items-center space-x-1">
+                    {% for i in "12345" %}
+                    <svg class="w-4 h-4 text-yellow-400" fill="currentColor" viewBox="0 0 24 24">
+                        <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
+                    </svg>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+
+        <!-- Grille de séries recommandées -->
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            {% for prediction in predictions %}
+            <div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg overflow-hidden border border-gray-200 dark:border-gray-700 hover:shadow-xl transition-shadow duration-300">
+                <!-- En-tête de la carte -->
+                <div class="bg-gradient-to-r from-mangacollec-red to-red-700 p-4">
+                    <div class="flex items-start justify-between">
+                        <div class="flex-1">
+                            <h3 class="text-xl font-bold text-white mb-1">{{ prediction.title|default:"Série recommandée" }}</h3>
+                            {% if prediction.author %}
+                            <p class="text-red-100">par {{ prediction.author }}</p>
+                            {% endif %}
+                        </div>
+                        <div class="text-right">
+                            <div class="bg-white/20 rounded-lg px-3 py-1">
+                                <div class="flex items-center space-x-1">
+                                    {% with score=prediction.score|default:0 %}
+                                    {% for i in "12345" %}
+                                        {% if forloop.counter <= score %}
+                                        <svg class="w-4 h-4 text-yellow-300" fill="currentColor" viewBox="0 0 24 24">
+                                            <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
+                                        </svg>
+                                        {% else %}
+                                        <svg class="w-4 h-4 text-gray-300" fill="currentColor" viewBox="0 0 24 24">
+                                            <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
+                                        </svg>
+                                        {% endif %}
+                                    {% endfor %}
+                                    {% endwith %}
+                                </div>
+                                <span class="text-xs text-red-100">{{ prediction.score|default:0 }}/5</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Contenu de la carte -->
+                <div class="p-6">
+                    <!-- Commentaire/Description -->
+                    <div class="mb-4">
+                        <h4 class="font-semibold text-gray-900 dark:text-white mb-2">Pourquoi cette série ?</h4>
+                        <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
+                            {{ prediction.comment|default:"Cette série correspond à vos goûts et préférences. Elle devrait vous offrir une expérience de lecture enrichissante selon votre profil et vos attentes actuelles." }}
+                        </p>
+                    </div>
+
+                    <!-- Métadonnées de la série -->
+                    <div class="space-y-3">
+                        {% if prediction.genre %}
+                        <div class="flex items-center space-x-2">
+                            <svg class="w-4 h-4 text-gray-500" fill="currentColor" viewBox="0 0 24 24">
+                                <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
+                            </svg>
+                            <span class="text-sm text-gray-600 dark:text-gray-400">Genre:</span>
+                            <span class="text-sm font-medium text-gray-900 dark:text-white">{{ prediction.genre }}</span>
+                        </div>
+                        {% endif %}
+
+                        {% if prediction.category %}
+                        <div class="flex items-center space-x-2">
+                            <svg class="w-4 h-4 text-gray-500" fill="currentColor" viewBox="0 0 24 24">
+                                <path d="M7 7h10v3l4-4-4-4v3H5v6h2V7z"/>
+                            </svg>
+                            <span class="text-sm text-gray-600 dark:text-gray-400">Catégorie:</span>
+                            <span class="text-sm font-medium text-gray-900 dark:text-white">{{ prediction.category }}</span>
+                        </div>
+                        {% endif %}
+
+                        {% if prediction.status %}
+                        <div class="flex items-center space-x-2">
+                            <svg class="w-4 h-4 text-gray-500" fill="currentColor" viewBox="0 0 24 24">
+                                <path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                            </svg>
+                            <span class="text-sm text-gray-600 dark:text-gray-400">Statut:</span>
+                            <span class="text-sm font-medium text-gray-900 dark:text-white">{{ prediction.status }}</span>
+                        </div>
+                        {% endif %}
+
+                        {% if prediction.volumes_count %}
+                        <div class="flex items-center space-x-2">
+                            <svg class="w-4 h-4 text-gray-500" fill="currentColor" viewBox="0 0 24 24">
+                                <path d="M4 6h16v2H4zm0 5h16v2H4zm0 5h16v2H4z"/>
+                            </svg>
+                            <span class="text-sm text-gray-600 dark:text-gray-400">Volumes:</span>
+                            <span class="text-sm font-medium text-gray-900 dark:text-white">{{ prediction.volumes_count }}</span>
+                        </div>
+                        {% endif %}
+                    </div>
+
+                    <!-- Actions -->
+                    <div class="mt-6 flex space-x-3">
+                        {% if prediction.series_id %}
+                        <a href="{% url 'series_detail' prediction.series_id %}" 
+                           class="flex-1 bg-mangacollec-red hover:bg-red-700 text-white text-center py-2 px-4 rounded-lg transition">
+                            Voir la série
+                        </a>
+                        {% endif %}
+                        <button type="button" class="flex-1 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-800 dark:text-gray-200 py-2 px-4 rounded-lg transition">
+                            Ajouter à ma liste
+                        </button>
+                    </div>
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+    {% endif %}
+
+    <!-- Actions finales -->
+    <div class="mt-10 flex flex-col sm:flex-row gap-4 justify-center">
+        <a href="{% url 'prediction' %}" 
+           class="inline-flex items-center justify-center px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition">
+            <svg class="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
+            </svg>
+            Nouvelle prédiction
+        </a>
+        
+        <a href="{% url 'index' %}" 
+           class="inline-flex items-center justify-center px-6 py-3 bg-gray-600 hover:bg-gray-700 text-white rounded-lg transition">
+            <svg class="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"/>
+            </svg>
+            Retour à l'accueil
+        </a>
+    </div>
+
+    <!-- Note informative -->
+    <div class="mt-8 bg-gray-50 dark:bg-gray-800/50 rounded-lg p-6 text-center">
+        <svg class="w-8 h-8 mx-auto text-gray-400 mb-3" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+        </svg>
+        <h3 class="text-lg font-medium text-gray-900 dark:text-white mb-2">Comment ça marche ?</h3>
+        <p class="text-gray-600 dark:text-gray-400">
+            Ces recommandations sont générées par notre algorithme de prédiction basé sur vos préférences, votre collection actuelle et votre historique de lecture. 
+            Plus vous utilisez BookSync, plus nos recommandations deviennent précises !
+        </p>
+    </div>
+</div>
+
+<style>
+.mangacollec-red {
+    background-color: #CF000A;
+}
+.mangacollec-red:hover {
+    background-color: #B0000A;
+}
+</style>
+
+{% endblock %}

--- a/book_sync/app/templates/prediction.html
+++ b/book_sync/app/templates/prediction.html
@@ -22,7 +22,7 @@
     </div>
 
     <!-- Formulaire interactif -->
-    <form id="prediction-form" method="POST" action="http://127.0.0.1:8001/predict/">
+    <form id="prediction-form" method="POST" action="{% url 'predict-responce' %}">
         {% csrf_token %}
         <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6 space-y-6">
         <!-- Question 1 : Âge -->

--- a/book_sync/app/urls.py
+++ b/book_sync/app/urls.py
@@ -6,4 +6,5 @@ urlpatterns = [
     path("collection/", views.collection, name="collection"),
     path("recommendation/", views.recommendation, name="recommendation"),
     path("prediction/", views.prediction, name="prediction"),
+    path("predict-responce/", views.predict_responce, name="predict-responce"),
 ]

--- a/book_sync/app/views.py
+++ b/book_sync/app/views.py
@@ -54,5 +54,146 @@ def save_age(request):
             return JsonResponse({'success': False, 'error': str(e)})
     return JsonResponse({'success': False, 'error': 'Mauvaise requête'})
 
+@login_required
+@user_passes_test(is_premium, login_url='/accounts/subscribe/')
+def predict_responce(request):
+    """Vue pour traiter et afficher les résultats de prédiction de l'API"""
+    
+    # Initialiser les variables
+    predictions = []
+    user_data = {}
+    api_error = None
+    
+    if request.method == 'POST':
+        # Récupérer et nettoyer les données du formulaire
+        user_data = {
+            'age': request.POST.get('user_age', ''),
+            'genre': request.POST.get('user_genre', ''),
+            'mood': request.POST.get('user_mood', ''),
+            'prediction_type': request.POST.get('prediction_type', ''),
+            'genres': [g.strip() for g in request.POST.get('genre_preference', '').split(',') if g.strip()],
+            'categories': [c.strip() for c in request.POST.get('category_preference', '').split(',') if c.strip()],
+            'comment': request.POST.get('user_comment', '')
+        }
+        
+        # Sauvegarder les données utilisateur dans la session
+        request.session['user_prediction_data'] = user_data
+        
+        # Préparer les données pour l'API (conserver les noms de champs originaux)
+        api_data = {
+            'user_age': user_data['age'],
+            'user_genre': user_data['genre'],
+            'genre_preference': request.POST.get('genre_preference', ''),
+            'category_preference': request.POST.get('category_preference', ''),
+            'user_comment': user_data['comment'],
+            'prediction_type': user_data['prediction_type'],
+            'collection': request.POST.get('collection', '{}'),
+            'read': request.POST.get('read', '{}'),
+            'user_mood': user_data['mood'],
+            'csrfmiddlewaretoken': request.POST.get('csrfmiddlewaretoken', '')
+        }
+        
+        # Appeler l'API de prédiction
+        try:
+            api_url = "http://127.0.0.1:8001/predict/"
+            print(f"Envoi des données à l'API: {api_url}")
+            print(f"Données envoyées: {api_data}")
+            
+            response = requests.post(api_url, data=api_data, timeout=30)
+            print(f"Réponse API - Status: {response.status_code}")
+            
+            if response.status_code == 200:
+                api_response = response.json()
+                print(f"Réponse API reçue: {api_response}")
+                
+                # Pour l'instant, l'API retourne les données de test
+                # Créer des prédictions factices basées sur les préférences utilisateur
+                predictions = generate_mock_predictions(user_data, api_response)
+                
+                # Sauvegarder les prédictions dans la session
+                request.session['predictions'] = predictions
+                
+            else:
+                api_error = f"Erreur API: Status {response.status_code} - {response.text}"
+                print(api_error)
+                
+        except requests.exceptions.Timeout:
+            api_error = "Timeout lors de l'appel à l'API de prédiction"
+            print(api_error)
+        except requests.exceptions.ConnectionError:
+            api_error = "Impossible de se connecter à l'API de prédiction"
+            print(api_error)
+        except requests.exceptions.RequestException as e:
+            api_error = f"Erreur lors de l'appel à l'API: {str(e)}"
+            print(api_error)
+        except Exception as e:
+            api_error = f"Erreur inattendue: {str(e)}"
+            print(api_error)
+    
+    # Si on accède directement à la page en GET
+    elif request.method == 'GET':
+        # Récupérer les données depuis la session si disponibles
+        predictions = request.session.get('predictions', [])
+        user_data = request.session.get('user_prediction_data', {})
+    
+    # Préparer le contexte pour le template
+    context = {
+        'predictions': predictions,
+        'user_data': user_data,
+        'api_error': api_error,
+    }
+    
+    return render(request, 'prediction-responce.html', context)
+
+def generate_mock_predictions(user_data, api_response):
+    """Génère des prédictions factices basées sur les données utilisateur"""
+    
+    # Prédictions de base selon les préférences
+    base_predictions = [
+        {
+            'title': 'One Piece',
+            'author': 'Eiichiro Oda',
+            'comment': f"Parfait pour votre humeur {user_data.get('mood', 'aventureuse')} ! Cette série d'aventure épique correspond à vos goûts.",
+            'genre': user_data.get('genres', ['Aventure'])[0] if user_data.get('genres') else 'Aventure',
+            'category': user_data.get('categories', ['Manga'])[0] if user_data.get('categories') else 'Manga',
+            'score': 5,
+            'status': 'En cours',
+            'volumes_count': '100+',
+            'series_id': 1
+        },
+        {
+            'title': 'Demon Slayer',
+            'author': 'Koyoharu Gotouge',
+            'comment': f"Une excellente série pour quelqu'un de {user_data.get('age', '25')} ans qui apprécie l'action et l'émotion.",
+            'genre': user_data.get('genres', ['Action'])[1] if len(user_data.get('genres', [])) > 1 else 'Action',
+            'category': user_data.get('categories', ['Manga'])[0] if user_data.get('categories') else 'Manga',
+            'score': 4,
+            'status': 'Terminé',
+            'volumes_count': '23',
+            'series_id': 2
+        },
+        {
+            'title': 'Spirited Away',
+            'author': 'Hayao Miyazaki',
+            'comment': f"Un classique du Studio Ghibli qui correspond parfaitement à votre profil {user_data.get('genre', 'passionné')} !",
+            'genre': 'Fantastique',
+            'category': 'Anime',
+            'score': 5,
+            'status': 'Film',
+            'volumes_count': '1',
+            'series_id': 3
+        }
+    ]
+    
+    # Filtrer selon le type de prédiction
+    if user_data.get('prediction_type') == 'collection':
+        # Simuler des recommandations de la collection existante
+        return base_predictions[:2]
+    else:
+        # Propositions de découverte
+        return base_predictions
+        
+    return base_predictions
+
 
 

--- a/book_sync/tools/test_emb.py
+++ b/book_sync/tools/test_emb.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+rag_reco.py — Ingestion CSV (44k volumes) + VectorStore Chroma + RAG + Recommandation
+LangChain + Azure OpenAI (embeddings + chat)
+Correction: nettoyage des métadonnées pour Chroma (pas de listes).
+"""
+
+import os
+import re
+import csv
+import json
+import argparse
+from typing import List, Dict, Any, Optional, Tuple
+
+from dotenv import load_dotenv
+
+# LangChain / OpenAI
+from langchain_openai import AzureOpenAIEmbeddings, AzureChatOpenAI
+from langchain_chroma import Chroma
+from langchain_core.documents import Document
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.runnables import RunnablePassthrough
+from langchain_core.output_parsers import StrOutputParser
+
+# ===========================================
+# Utilitaires de nettoyage & normalisation
+# ===========================================
+
+ACCENT_MAP = str.maketrans(
+    "àáâäæçéèêëîïôöùúûüÿñœÀÁÂÄÆÇÉÈÊËÎÏÔÖÙÚÛÜŸÑŒ",
+    "aaaaaceeeeii oouuuynoeAAAAACEEEEIIOOUUUYN OE".replace(" ", "")
+)
+
+def slugify(s: str) -> str:
+    if s is None:
+        return ""
+    s = s.strip().translate(ACCENT_MAP).lower()
+    s = re.sub(r"[^a-z0-9]+", "_", s)
+    return re.sub(r"_+", "_", s).strip("_")
+
+def split_tags(field: str) -> List[str]:
+    if field is None:
+        return []
+    field = field.strip().strip(";")
+    parts = [p.strip() for p in re.split(r",\s*", field) if p.strip()]
+    return parts
+
+def normalize_tags(tags: List[str]) -> List[str]:
+    return [slugify(t) for t in tags if t]
+
+def safe_int(s: str, default: int = 0) -> int:
+    try:
+        return int(s)
+    except Exception:
+        return default
+
+# ===========================================
+# Nettoyage des métadonnées pour Chroma
+# ===========================================
+
+def clean_metadata(metadata: dict) -> dict:
+    cleaned = {}
+    for k, v in metadata.items():
+        if isinstance(v, list):
+            cleaned[k] = ", ".join(map(str, v))
+        elif isinstance(v, dict):
+            cleaned[k] = json.dumps(v, ensure_ascii=False)
+        else:
+            cleaned[k] = v
+    return cleaned
+
+# ===========================================
+# Lecture CSV tolérante
+# ===========================================
+
+def smart_csv_reader(path: str) -> List[Dict[str, str]]:
+    rows: List[Dict[str, str]] = []
+    def clean_header(h: str) -> str:
+        return h.strip().strip(";").replace('""', '"').strip('"')
+    with open(path, "r", encoding="utf-8", newline="") as f:
+        raw = f.read()
+    cleaned = raw.replace('""', '"')
+    try:
+        lines = cleaned.splitlines()
+        if not lines:
+            return rows
+        headers = [clean_header(h) for h in next(csv.reader([lines[0]]))]
+        reader = csv.DictReader(lines[1:], fieldnames=headers)
+        for r in reader:
+            fixed = {k: (v.strip().strip(";") if isinstance(v, str) else v) for k, v in r.items()}
+            rows.append(fixed)
+        if rows and all(k in rows[0] and rows[0][k] == k for k in ["serie","genre","kinds","volume_id","volume_number","content"]):
+            rows.pop(0)
+        return rows
+    except Exception:
+        pass
+    # fallback regex
+    fallback = []
+    for line in raw.splitlines()[1:]:
+        parts = re.findall(r'"(.*?)"', line)
+        if len(parts) >= 6:
+            fallback.append({
+                "serie": parts[0],
+                "genre": parts[1],
+                "kinds": parts[2],
+                "volume_id": parts[3],
+                "volume_number": parts[4],
+                "content": parts[5],
+            })
+    return fallback
+
+# ===========================================
+# Construction des Documents
+# ===========================================
+
+def build_documents(rows: List[Dict[str, str]]) -> List[Document]:
+    docs: List[Document] = []
+    for r in rows:
+        serie = (r.get("serie") or "").strip()
+        genre = (r.get("genre") or "").strip()
+        kinds = (r.get("kinds") or "").strip()
+        volume_id = (r.get("volume_id") or "").strip()
+        volume_number_raw = (r.get("volume_number") or "").strip()
+        content = (r.get("content") or "").strip()
+
+        genres_list = split_tags(genre)
+        kinds_list = split_tags(kinds)
+
+        meta = {
+            "id": volume_id,
+            "serie": serie,
+            "serie_normalized": slugify(serie),
+            "genres": genres_list,
+            "genres_normalized": normalize_tags(genres_list),
+            "kinds": kinds_list,
+            "kinds_normalized": normalize_tags(kinds_list),
+            "volume_number": safe_int(volume_number_raw),
+        }
+
+        # Nettoyage Chroma (pas de listes)
+        meta = clean_metadata(meta)
+
+        header = f"Série: {serie}\nGenres: {', '.join(genres_list)}\nThèmes: {', '.join(kinds_list)}\nTome: {meta['volume_number']}\n\n"
+        page_content = header + content
+
+        docs.append(Document(page_content=page_content, metadata=meta))
+    return docs
+
+# ===========================================
+# Embeddings / LLM / VectorStore
+# ===========================================
+
+def make_embeddings() -> AzureOpenAIEmbeddings:
+    deployment = os.environ.get("AZURE_OPENAI_EMBEDDING_DEPLOYMENT")
+    if not deployment:
+        raise RuntimeError("AZURE_OPENAI_EMBEDDING_DEPLOYMENT manquant")
+    return AzureOpenAIEmbeddings(
+        azure_deployment=deployment,
+        api_version=os.environ.get("AZURE_OPENAI_API_VERSION", "2024-02-01")
+    )
+
+def make_chat_llm(temperature: float = 0.2) -> AzureChatOpenAI:
+    deployment = os.environ.get("AZURE_OPENAI_CHAT_DEPLOYMENT")
+    if not deployment:
+        raise RuntimeError("AZURE_OPENAI_CHAT_DEPLOYMENT manquant")
+    return AzureChatOpenAI(
+        azure_deployment=deployment,
+        api_version=os.environ.get("AZURE_OPENAI_API_VERSION", "2024-02-01"),
+        temperature=temperature,
+    )
+
+def get_vectorstore(persist_directory: str, embeddings: AzureOpenAIEmbeddings) -> Chroma:
+    return Chroma(
+        collection_name="manga_volumes",
+        embedding_function=embeddings,
+        persist_directory=persist_directory
+    )
+
+def build_index(csv_path: str, persist_directory: str) -> Tuple[int, int]:
+    rows = smart_csv_reader(csv_path)
+    if not rows:
+        raise RuntimeError("CSV vide ou illisible")
+    docs = build_documents(rows)
+    embeddings = make_embeddings()
+    vs = Chroma.from_documents(
+        documents=docs,
+        embedding=embeddings,
+        collection_name="manga_volumes",
+        persist_directory=persist_directory
+    )
+    vs.persist()
+    return len(rows), len(docs)
+
+# ===========================================
+# Recherche / RAG
+# ===========================================
+
+def search(
+    query: str,
+    persist_directory: str,
+    k: int = 5,
+    filter_genre: Optional[str] = None,
+    include_kinds: Optional[List[str]] = None,
+    exclude_kinds: Optional[List[str]] = None,
+) -> List[Document]:
+    embeddings = make_embeddings()
+    vs = get_vectorstore(persist_directory, embeddings)
+    chroma_filter: Dict[str, Any] = {}
+
+    if filter_genre:
+        chroma_filter["genres_normalized"] = {"$contains": slugify(filter_genre)}
+    if include_kinds:
+        chroma_filter["kinds_normalized"] = {"$in": [slugify(k) for k in include_kinds]}
+    if exclude_kinds:
+        chroma_filter["kinds_normalized"] = {"$nin": [slugify(k) for k in exclude_kinds]}
+
+    docs = vs.similarity_search(query, k=k, filter=chroma_filter if chroma_filter else None)
+    return docs
+
+def build_rag_chain(persist_directory: str):
+    embeddings = make_embeddings()
+    vs = get_vectorstore(persist_directory, embeddings)
+    retriever = vs.as_retriever(search_kwargs={"k": 5})
+
+    system_prompt = (
+        "Vous êtes un assistant de recommandation et d'information sur des séries et leurs volumes. "
+        "Répondez en français, de façon concise, en citant les séries et tomes utilisés. "
+        "Si l'information est absente du contexte, dites-le clairement."
+    )
+    prompt = ChatPromptTemplate.from_messages([
+        ("system", system_prompt),
+        ("human", "Question: {question}\n\nContexte:\n{context}")
+    ])
+
+    llm = make_chat_llm(temperature=0.2)
+
+    def format_docs(docs: List[Document]) -> str:
+        blocks = []
+        for d in docs:
+            meta = d.metadata
+            head = f"- {meta.get('serie')} (Tome {meta.get('volume_number')})"
+            blocks.append(head + "\n" + d.page_content[:1200])
+        return "\n\n".join(blocks)
+
+    chain = (
+        {"question": RunnablePassthrough(), "context": retriever | format_docs}
+        | prompt
+        | llm
+        | StrOutputParser()
+    )
+    return chain
+
+# ===========================================
+# Recommandation simple
+# ===========================================
+
+def recommend_books(
+    persist_directory: str,
+    user_profile: Dict[str, Any],
+    k: int = 10
+) -> List[Dict[str, Any]]:
+    likes_genres = [slugify(g) for g in user_profile.get("like_genres", [])]
+    dislikes_genres = [slugify(g) for g in user_profile.get("dislike_genres", [])]
+    likes_kinds = [slugify(kd) for kd in user_profile.get("like_kinds", [])]
+    dislikes_kinds = [slugify(kd) for kd in user_profile.get("dislike_kinds", [])]
+
+    query_parts = []
+    if likes_kinds:
+        query_parts.append("Thèmes: " + ", ".join(likes_kinds))
+    if likes_genres:
+        query_parts.append("Genres: " + ", ".join(likes_genres))
+    base_query = "Recherche de séries et tomes pertinents. " + " | ".join(query_parts)
+
+    include_kinds = likes_kinds or None
+    docs = search(
+        base_query,
+        persist_directory=persist_directory,
+        k=k*3,
+        filter_genre=likes_genres[0] if likes_genres else None,
+        include_kinds=include_kinds
+    )
+
+    def score_doc(d: Document) -> int:
+        s = 0
+        for g in likes_genres:
+            if g in d.metadata.get("genres_normalized", ""):
+                s += 2
+        for kd in likes_kinds:
+            if kd in d.metadata.get("kinds_normalized", ""):
+                s += 1
+        return s
+
+    docs_sorted = sorted(docs, key=score_doc, reverse=True)[:k]
+    return [{"serie": d.metadata.get("serie"), "volume": d.metadata.get("volume_number")} for d in docs_sorted]
+
+# ===========================================
+# CLI
+# ===========================================
+
+def main():
+    load_dotenv()
+    parser = argparse.ArgumentParser(description="RAG Manga Reco Indexer / Searcher")
+    parser.add_argument("--csv", type=str, required=True, help="Chemin vers le CSV")
+    parser.add_argument("--persist", type=str, required=True, help="Répertoire Chroma")
+    args = parser.parse_args()
+
+    print(f"Indexation du CSV {args.csv}...")
+    n_rows, n_docs = build_index(args.csv, args.persist)
+    print(f"✅ {n_rows} lignes lues, {n_docs} documents indexés dans {args.persist}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Create prediction-responce.html template with proper UTF-8 encoding
- Add predict_responce view to handle API calls and display results
- Update prediction form to send data to Django view instead of direct API
- Add URL routing for predict-responce endpoint
- Include user message display in prediction criteria summary
- Implement mock predictions with personalized comments
- Add comprehensive error handling for API failures